### PR TITLE
Tensorflow version 1.13 to 1.14 (for Google Colab)

### DIFF
--- a/lab1/Part1_tensorflow.ipynb
+++ b/lab1/Part1_tensorflow.ipynb
@@ -83,7 +83,7 @@
       },
       "cell_type": "code",
       "source": [
-        "is_correct_tf_version = '1.13.' in tf.__version__\n",
+        "is_correct_tf_version = '1.14.' in tf.__version__\n",
         "assert is_correct_tf_version, \"Wrong tensorflow version {} installed\".format(tf.__version__)\n",
         "\n",
         "is_eager_enabled = tf.executing_eagerly()\n",
@@ -99,7 +99,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "TensorFlow is set to release the next major version of TensorFlow, [TensorFlow 2.0](https://www.tensorflow.org/community/roadmap#tensorflow_20_is_coming), very soon. In this set of labs we'll be working in TensorFlow 1.12.0. The 6.S191 team is **Eager** to show you this version, as it features a (relatively) new imperative programming style called Eager execution. Under Eager execution, TensorFlow operations execute immediately as they're called from Python (which wasn't always the case!). This allows for fast debugging and a more intuitive way to get started with TensorFlow.\n",
+        "TensorFlow is set to release the next major version of TensorFlow, [TensorFlow 2.0](https://www.tensorflow.org/community/roadmap#tensorflow_20_is_coming), very soon. In this set of labs we'll be working in TensorFlow 1.14.0. The 6.S191 team is **Eager** to show you this version, as it features a (relatively) new imperative programming style called Eager execution. Under Eager execution, TensorFlow operations execute immediately as they're called from Python (which wasn't always the case!). This allows for fast debugging and a more intuitive way to get started with TensorFlow.\n",
         "\n"
       ]
     },

--- a/lab1/Part1_tensorflow_solution.ipynb
+++ b/lab1/Part1_tensorflow_solution.ipynb
@@ -83,7 +83,7 @@
       },
       "cell_type": "code",
       "source": [
-        "is_correct_tf_version = '1.13.' in tf.__version__\n",
+        "is_correct_tf_version = '1.14.' in tf.__version__\n",
         "assert is_correct_tf_version, \"Wrong tensorflow version {} installed\".format(tf.__version__)\n",
         "\n",
         "is_eager_enabled = tf.executing_eagerly()\n",
@@ -99,7 +99,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "TensorFlow is set to release the next major version of TensorFlow, [TensorFlow 2.0](https://www.tensorflow.org/community/roadmap#tensorflow_20_is_coming), very soon. In this set of labs we'll be working in TensorFlow 1.12.0. The 6.S191 team is **Eager** to show you this version, as it features a (relatively) new imperative programming style called Eager execution. Under Eager execution, TensorFlow operations execute immediately as they're called from Python (which wasn't always the case!). This allows for fast debugging and a more intuitive way to get started with TensorFlow.\n",
+        "TensorFlow is set to release the next major version of TensorFlow, [TensorFlow 2.0](https://www.tensorflow.org/community/roadmap#tensorflow_20_is_coming), very soon. In this set of labs we'll be working in TensorFlow 1.14.0. The 6.S191 team is **Eager** to show you this version, as it features a (relatively) new imperative programming style called Eager execution. Under Eager execution, TensorFlow operations execute immediately as they're called from Python (which wasn't always the case!). This allows for fast debugging and a more intuitive way to get started with TensorFlow.\n",
         "\n"
       ]
     },

--- a/lab1/Part2_music_generation.ipynb
+++ b/lab1/Part2_music_generation.ipynb
@@ -85,7 +85,7 @@
         "\n",
         "import introtodeeplearning_labs as util\n",
         "\n",
-        "is_correct_tf_version = '1.13.0' in tf.__version__\n",
+        "is_correct_tf_version = '1.14.0' in tf.__version__\n",
         "assert is_correct_tf_version, \"Wrong tensorflow version ({}) installed\".format(tf.__version__)\n",
         "\n",
         "is_eager_enabled = tf.executing_eagerly()\n",

--- a/lab1/Part2_music_generation_solution.ipynb
+++ b/lab1/Part2_music_generation_solution.ipynb
@@ -85,7 +85,7 @@
         "\n",
         "import introtodeeplearning_labs as util\n",
         "\n",
-        "is_correct_tf_version = '1.13.0' in tf.__version__\n",
+        "is_correct_tf_version = '1.14.0' in tf.__version__\n",
         "assert is_correct_tf_version, \"Wrong tensorflow version ({}) installed\".format(tf.__version__)\n",
         "\n",
         "is_eager_enabled = tf.executing_eagerly()\n",


### PR DESCRIPTION
Hello, Google Colab uses Tensorflow 1.14 now and this pull request tries to maintain the code for Colab.
Best regards,
Ozan